### PR TITLE
Android 14 issue

### DIFF
--- a/android/src/main/java/com/reactnativea11y/services/KeyboardService.java
+++ b/android/src/main/java/com/reactnativea11y/services/KeyboardService.java
@@ -5,6 +5,7 @@ import static android.content.res.Configuration.HARDKEYBOARDHIDDEN_NO;
 import static android.content.res.Configuration.KEYBOARD_NOKEYS;
 import static android.content.res.Configuration.KEYBOARD_UNDEFINED;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -73,6 +74,7 @@ public class KeyboardService implements LifecycleEventListener {
   }
 
   @Override
+  @SuppressLint("UnspecifiedRegisterReceiverFlag")
   public void onHostResume() {
     final Activity activity = context.getCurrentActivity();
 
@@ -86,11 +88,10 @@ public class KeyboardService implements LifecycleEventListener {
      * exported to all other apps on the device: either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED
      * <a href="https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported"/>
      */
-    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
-      activity.registerReceiver(receiver, new IntentFilter(ON_CONFIGURATION_CHANGED), context.RECEIVER_NOT_EXPORTED)
+      activity.registerReceiver(receiver, new IntentFilter(ON_CONFIGURATION_CHANGED), Context.RECEIVER_NOT_EXPORTED);
     } else {
-      activity.registerReceiver(receiver, new IntentFilter(ON_CONFIGURATION_CHANGED))
+      activity.registerReceiver(receiver, new IntentFilter(ON_CONFIGURATION_CHANGED));
     }
   }
 

--- a/android/src/main/java/com/reactnativea11y/services/KeyboardService.java
+++ b/android/src/main/java/com/reactnativea11y/services/KeyboardService.java
@@ -79,7 +79,19 @@ public class KeyboardService implements LifecycleEventListener {
     if (activity == null) {
       return;
     }
-    activity.registerReceiver(receiver, new IntentFilter(ON_CONFIGURATION_CHANGED));
+
+    /**
+     * Starting with Android 14, apps and services that target Android 14 and use context-registered
+     * receivers are required to specify a flag to indicate whether or not the receiver should be
+     * exported to all other apps on the device: either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED
+     * <a href="https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported"/>
+     */
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
+      activity.registerReceiver(receiver, new IntentFilter(ON_CONFIGURATION_CHANGED), context.RECEIVER_NOT_EXPORTED)
+    } else {
+      activity.registerReceiver(receiver, new IntentFilter(ON_CONFIGURATION_CHANGED))
+    }
   }
 
   @Override

--- a/android/src/main/java/com/reactnativea11y/services/KeyboardService.java
+++ b/android/src/main/java/com/reactnativea11y/services/KeyboardService.java
@@ -14,6 +14,7 @@ import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.util.Log;
 import android.view.View;
+import android.os.Build;
 
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
Starting Android 14, the `registerReceiver` function requires an extra parameter, specifying either `RECEIVER_NOT_EXPORTED` or `RECEIVER_EXPORTED`.  Read more about that here: https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported

Without that parameter the code will throw an error, causing our app to crash with Android 14.

I've updated the code with a backwards compatibility check, though I'm unsure whether to use `RECEIVER_NOT_EXPORTED` or `RECEIVER_EXPORTED`. 

I've now used `RECEIVER_NOT_EXPORTED`, but please let me know if I need to change that 🙂 