### PR TITLE
[ISSUE-77] fix: Android border styles fix

### DIFF
--- a/android/src/legacy/RCA11yFocusWrapperManagerSpec.java
+++ b/android/src/legacy/RCA11yFocusWrapperManagerSpec.java
@@ -1,8 +1,8 @@
 package com.reactnativea11y;
 
 import android.view.ViewGroup;
-import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.views.view.ReactViewManager;
 
-public abstract class RCA11yFocusWrapperManagerSpec<T extends ViewGroup> extends ViewGroupManager<T> {
+public abstract class RCA11yFocusWrapperManagerSpec<T extends ViewGroup> extends ReactViewManager {
   public abstract void setCanBeFocused(T wrapper, boolean canBeFocused);
 }

--- a/android/src/main/java/com/reactnativea11y/RCA11yFocusWrapperManager.java
+++ b/android/src/main/java/com/reactnativea11y/RCA11yFocusWrapperManager.java
@@ -12,12 +12,13 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import java.util.Map;
 import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.views.view.ReactViewGroup;
 import com.reactnativea11y.events.FocusChangeEvent;
 import com.reactnativea11y.events.KeyPressDownEvent;
 import com.reactnativea11y.events.KeyPressUpEvent;
 import com.reactnativea11y.services.KeyboardKeyPressHandler;
 
-public class RCA11yFocusWrapperManager extends com.reactnativea11y.RCA11yFocusWrapperManagerSpec<RCA11yFocusWrapper> {
+public class RCA11yFocusWrapperManager extends com.reactnativea11y.RCA11yFocusWrapperManagerSpec<ReactViewGroup> {
 
   public static final String NAME = "RCA11yFocusWrapper";
   private KeyboardKeyPressHandler keyboardKeyPressHandler;
@@ -28,13 +29,14 @@ public class RCA11yFocusWrapperManager extends com.reactnativea11y.RCA11yFocusWr
   }
 
   @Override
-  public RCA11yFocusWrapper createViewInstance(ThemedReactContext context) {
+  public ReactViewGroup createViewInstance(ThemedReactContext context) {
+
     this.keyboardKeyPressHandler = new KeyboardKeyPressHandler();
-    return new RCA11yFocusWrapper(context);
+    return super.createViewInstance(context);
   }
 
 
-  private void onKeyPressHandler(RCA11yFocusWrapper viewGroup, int keyCode, KeyEvent keyEvent, ThemedReactContext reactContext) {
+  private void onKeyPressHandler(ReactViewGroup viewGroup, int keyCode, KeyEvent keyEvent, ThemedReactContext reactContext) {
     KeyboardKeyPressHandler.PressInfo pressInfo = keyboardKeyPressHandler.getEventsFromKeyPress(keyCode,keyEvent);
 
     if(pressInfo.firePressDownEvent) {
@@ -50,7 +52,7 @@ public class RCA11yFocusWrapperManager extends com.reactnativea11y.RCA11yFocusWr
   }
 
   @Override
-  protected void addEventEmitters(final ThemedReactContext reactContext, RCA11yFocusWrapper viewGroup) {
+  protected void addEventEmitters(final ThemedReactContext reactContext, ReactViewGroup viewGroup) {
     viewGroup.setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
       @Override
       public void onChildViewAdded(View parent, View child) {
@@ -72,8 +74,6 @@ public class RCA11yFocusWrapperManager extends com.reactnativea11y.RCA11yFocusWr
     });
   }
 
-
-
   @Nullable
   @Override
   public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
@@ -91,7 +91,7 @@ public class RCA11yFocusWrapperManager extends com.reactnativea11y.RCA11yFocusWr
 
   @Override
   @ReactProp(name = "canBeFocused", defaultBoolean = true)
-  public void setCanBeFocused(RCA11yFocusWrapper wrapper, boolean canBeFocused) {
+  public void setCanBeFocused(ReactViewGroup wrapper, boolean canBeFocused) {
     wrapper.setClickable(canBeFocused);
     wrapper.setFocusable(canBeFocused);
     wrapper.setDescendantFocusability(

--- a/android/src/newarch/RCA11yFocusWrapperManagerSpec.java
+++ b/android/src/newarch/RCA11yFocusWrapperManagerSpec.java
@@ -1,32 +1,19 @@
 package com.reactnativea11y;
 
-import android.view.ViewGroup;
-
 import androidx.annotation.Nullable;
 
 import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.viewmanagers.RCA11yFocusWrapperManagerDelegate;
 import com.facebook.react.viewmanagers.RCA11yFocusWrapperManagerInterface;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.facebook.react.views.view.ReactViewManager;
 import com.facebook.soloader.SoLoader;
-import com.facebook.react.uimanager.ViewGroupManager;
 
 
-public abstract class RCA11yFocusWrapperManagerSpec<T extends ViewGroup> extends ViewGroupManager<T> implements RCA11yFocusWrapperManagerInterface<T> {
+public abstract class RCA11yFocusWrapperManagerSpec<T extends ReactViewGroup> extends ReactViewManager implements RCA11yFocusWrapperManagerInterface<T> {
   static {
     if (BuildConfig.CODEGEN_MODULE_REGISTRATION != null) {
       SoLoader.loadLibrary(BuildConfig.CODEGEN_MODULE_REGISTRATION);
     }
-  }
-
-  private final ViewManagerDelegate<T> mDelegate;
-
-  public RCA11yFocusWrapperManagerSpec() {
-    mDelegate = new RCA11yFocusWrapperManagerDelegate(this);
-  }
-
-  @Nullable
-  @Override
-  protected ViewManagerDelegate<T> getDelegate() {
-    return mDelegate;
   }
 }

--- a/android/src/oldarch/RCA11yFocusWrapperManagerSpec.java
+++ b/android/src/oldarch/RCA11yFocusWrapperManagerSpec.java
@@ -1,8 +1,8 @@
 package com.reactnativea11y;
 
 import android.view.ViewGroup;
-import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.views.view.ReactViewManager;
 
-public abstract class RCA11yFocusWrapperManagerSpec<T extends ViewGroup> extends ViewGroupManager<T> {
+public abstract class RCA11yFocusWrapperManagerSpec<T extends ViewGroup> extends ReactViewManager {
   public abstract void setCanBeFocused(T wrapper, boolean canBeFocused);
 }

--- a/examples/A11yNewArch/src/components/Button/Button.tsx
+++ b/examples/A11yNewArch/src/components/Button/Button.tsx
@@ -12,7 +12,17 @@ type Props = {
 };
 
 export const Button = React.forwardRef<View, Props>(
-  ({ title, onPress, style, focusStyle, canBeFocused = true, accessible = true }, ref) => {
+  (
+    {
+      title,
+      onPress,
+      style,
+      focusStyle,
+      canBeFocused = true,
+      accessible = true,
+    },
+    ref,
+  ) => {
     const fStyle = ({ focused }: { focused: boolean }) =>
       focused && styles.focus;
 
@@ -49,10 +59,16 @@ const styles = StyleSheet.create({
   container: {
     padding: 10,
     borderColor: "#111",
+    borderWidth: 2,
     borderRadius: 50,
     minWidth: 100,
   },
-  font: { fontSize: 18, textAlign:'center', fontWeight: "bold", color: "#111" },
+  font: {
+    fontSize: 18,
+    textAlign: "center",
+    fontWeight: "bold",
+    color: "#111",
+  },
   focus: {
     backgroundColor: "#aaa",
     borderColor: "#eee",


### PR DESCRIPTION
`ViewGroupManager` doesn't support border styles by default, to add border styles `ReactViewManager` has been used instead.