### PR TITLE
fix gradle.properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ A11y_kotlinVersion=1.7.0
 A11y_minSdkVersion=21
 A11y_targetSdkVersion=31
 A11y_compileSdkVersion=31
-A11y_ndkversion=21.4.7075529
+A11y_ndkVersion=21.4.7075529


### PR DESCRIPTION
project.properties["A11y_" + name] doesn't work. the falsey value expects `A11y_ndkVersion` to exist in https://github.com/ArturKalach/react-native-a11y/blob/master/android/build.gradle#L50